### PR TITLE
Makes code pep8 compliant

### DIFF
--- a/netstat.py
+++ b/netstat.py
@@ -10,145 +10,168 @@ PROC_UDP4 = "/proc/net/udp"
 PROC_TCP6 = "/proc/net/tcp6"
 PROC_UDP6 = "/proc/net/udp6"
 PROC_PACKET = "/proc/net/packet"
-TCP_STATE = {
-        '01':'ESTABLISHED',
-        '02':'SYN_SENT',
-        '03':'SYN_RECV',
-        '04':'FIN_WAIT1',
-        '05':'FIN_WAIT2',
-        '06':'TIME_WAIT',
-        '07':'CLOSE',
-        '08':'CLOSE_WAIT',
-        '09':'LAST_ACK',
-        '0A':'LISTEN',
-        '0B':'CLOSING'
-        }
+TCP_STATE = {'01': 'ESTABLISHED',
+             '02': 'SYN_SENT',
+             '03': 'SYN_RECV',
+             '04': 'FIN_WAIT1',
+             '05': 'FIN_WAIT2',
+             '06': 'TIME_WAIT',
+             '07': 'CLOSE',
+             '08': 'CLOSE_WAIT',
+             '09': 'LAST_ACK',
+             '0A': 'LISTEN',
+             '0B': 'CLOSING'
+             }
+
 
 def _tcp4load():
     ''' Read the table of tcp connections & remove the header  '''
-    with open(PROC_TCP4,'r') as f:
+    with open(PROC_TCP4, 'r') as f:
         content = f.readlines()
         content.pop(0)
     return content
+
 
 def _tcp6load():
     ''' Read the table of tcpv6 connections & remove the header'''
-    with open(PROC_TCP6,'r') as f:
+    with open(PROC_TCP6, 'r') as f:
         content = f.readlines()
         content.pop(0)
     return content
+
 
 def _udp4load():
     '''Read the table of udp connections & remove the header '''
-    with open(PROC_UDP4,'r') as f:
+    with open(PROC_UDP4, 'r') as f:
         content = f.readlines()
         content.pop(0)
     return content
+
 
 def _udp6load():
     '''Read the table of udp connections & remove the header '''
-    with open(PROC_UDP6,'r') as f:
+    with open(PROC_UDP6, 'r') as f:
         content = f.readlines()
         content.pop(0)
     return content
+
 
 def _packetload():
-    ''' Read the contents of /proc/net/packet for finding processes with packet sockets '''
-    with open(PROC_PACKET,'r') as f:
+    '''
+    Read the contents of /proc/net/packet for finding processes with packet
+    sockets
+    '''
+    with open(PROC_PACKET, 'r') as f:
         content = f.readlines()
         content.pop(0)
     return content
 
+
 def _hex2dec(s):
-    return str(int(s,16))
+    return str(int(s, 16))
+
 
 def _ip(s):
-    ip = [(_hex2dec(s[6:8])),(_hex2dec(s[4:6])),(_hex2dec(s[2:4])),(_hex2dec(s[0:2]))]
+    ip = [(_hex2dec(s[6:8])), (_hex2dec(s[4:6])), (_hex2dec(s[2:4])),
+          (_hex2dec(s[0:2]))]
     return '.'.join(ip)
 
+
 def _ip6(s):
-    #this may need to be converted to a string to work properly.
-    ip = [s[6:8],s[4:6],s[2:4],s[0:2],s[12:14],s[14:16],s[10:12],s[8:10],s[22:24],s[20:22],s[18:20],s[16:18],s[30:32],s[28:30],s[26:28],s[24:26]]
+    # this may need to be converted to a string to work properly.
+    ip = [s[6:8], s[4:6], s[2:4], s[0:2], s[12:14], s[14:16], s[10:12],
+          s[8:10], s[22:24], s[20:22], s[18:20], s[16:18], s[30:32], s[28:30],
+          s[26:28], s[24:26]]
     return ':'.join(ip)
 
+
 def _remove_empty(array):
-    return [x for x in array if x !='']
+    return [x for x in array if x != '']
+
 
 def _convert_ipv4_port(array):
-    host,port = array.split(':')
-    return _ip(host),_hex2dec(port)
+    host, port = array.split(':')
+    return _ip(host), _hex2dec(port)
+
 
 def _convert_ipv6_port(array):
-    host,port = array.split(':')
-    return _ip6(host),_hex2dec(port)
+    host, port = array.split(':')
+    return _ip6(host), _hex2dec(port)
+
 
 def netstat_tcp4():
     '''
     Function to return a list with status of tcp connections on Linux systems.
-    Please note that in order to return the pid of of a network process running on the
-    system, this script must be ran as root.
+    Please note that in order to return the pid of of a network process running
+    on the system, this script must be ran as root.
     '''
 
-    tcpcontent =_tcp4load()
+    tcpcontent = _tcp4load()
     tcpresult = []
     for line in tcpcontent:
-        line_array = _remove_empty(line.split(' '))     # Split lines and remove empty spaces.
-        l_host,l_port = _convert_ipv4_port(line_array[1]) # Convert ipaddress and port from hex to decimal.
-        r_host,r_port = _convert_ipv4_port(line_array[2])
+        line_array = _remove_empty(line.split(' '))  # Split lines and remove empty spaces.
+        l_host, l_port = _convert_ipv4_port(line_array[1])  # Convert ipaddress and port from hex to decimal.
+        r_host, r_port = _convert_ipv4_port(line_array[2])
         tcp_id = line_array[0]
         state = TCP_STATE[line_array[3]]
-        uid = pwd.getpwuid(int(line_array[7]))[0]       # Get user from UID.
-        inode = line_array[9]                           # Need the inode to get process pid.
-        pid = _get_pid_of_inode(inode)                  # Get pid prom inode.
-        try:                                            # try read the process name.
+        uid = pwd.getpwuid(int(line_array[7]))[0]  # Get user from UID.
+        inode = line_array[9]  # Need the inode to get process pid.
+        pid = _get_pid_of_inode(inode)  # Get pid prom inode.
+        try:  # try read the process name.
             exe = os.readlink('/proc/'+pid+'/exe')
         except:
             exe = None
 
-        nline = [tcp_id, uid, l_host+':'+l_port, r_host+':'+r_port, state, pid, exe]
+        nline = [tcp_id, uid, l_host+':'+l_port, r_host+':'+r_port, state, pid,
+                 exe]
         tcpresult.append(nline)
     return tcpresult
 
+
 def netstat_tcp6():
     '''
-    This function returns a list of tcp connections utilizing ipv6. Please note that in order to return the pid of of a
-    network process running on the system, this script must be ran as root.
+    This function returns a list of tcp connections utilizing ipv6. Please note
+    that in order to return the pid of of a network process running on the
+    system, this script must be ran as root.
     '''
     tcpcontent = _tcp6load()
     tcpresult = []
     for line in tcpcontent:
         line_array = _remove_empty(line.split(' '))
-        l_host,l_port = _convert_ipv6_port(line_array[1])
-        r_host,r_port = _convert_ipv6_port(line_array[2])
+        l_host, l_port = _convert_ipv6_port(line_array[1])
+        r_host, r_port = _convert_ipv6_port(line_array[2])
         tcp_id = line_array[0]
         state = TCP_STATE[line_array[3]]
-        uid = pwd.getpwuid(int(line_array[7])) [0]
+        uid = pwd.getpwuid(int(line_array[7]))[0]
         inode = line_array[9]
         pid = _get_pid_of_inode(inode)
-        try:                                            # try read the process name.
+        try:                                      # try read the process name.
             exe = os.readlink('/proc/'+pid+'/exe')
         except:
             exe = None
 
-        nline = [tcp_id, uid, l_host+':'+l_port, r_host+':'+r_port, state, pid, exe]
+        nline = [tcp_id, uid, l_host+':'+l_port, r_host+':'+r_port, state, pid,
+                 exe]
         tcpresult.append(nline)
     return tcpresult
 
+
 def netstat_udp4():
     '''
-    Function to return a list with status of udp connections on Linux systems. Please note that UDP is stateless, so
-    state will always be blank. Please note that in order to return the pid of of a network process running on the
-    system, this script must be ran as root.
+    Function to return a list with status of udp connections on Linux systems.
+    Please note that UDP is stateless, so state will always be blank.
+    Please note that in order to return the pid of
+    a network process running on the system, this script must be ran as root.
     '''
 
-    udpcontent =_udp4load()
+    udpcontent = _udp4load()
     udpresult = []
     for line in udpcontent:
         line_array = _remove_empty(line.split(' '))
-        l_host,l_port = _convert_ipv4_port(line_array[1])
-        r_host,r_port = _convert_ipv4_port(line_array[2])
+        l_host, l_port = _convert_ipv4_port(line_array[1])
+        r_host, r_port = _convert_ipv4_port(line_array[2])
         udp_id = line_array[0]
-        udp_state ='Stateless' #UDP is stateless
+        udp_state = 'Stateless'  # UDP is stateless
         uid = pwd.getpwuid(int(line_array[7]))[0]
         inode = line_array[9]
         pid = _get_pid_of_inode(inode)
@@ -157,25 +180,28 @@ def netstat_udp4():
         except:
             exe = None
 
-        nline = [udp_id, uid, l_host+':'+l_port, r_host+':'+r_port, udp_state, pid, exe]
+        nline = [udp_id, uid, l_host+':'+l_port, r_host+':'+r_port, udp_state,
+                 pid, exe]
         udpresult.append(nline)
     return udpresult
+
 
 def netstat_udp6():
     '''
-    Function to return a list of udp connection utilizing ipv6. Please note that UDP is stateless, so state will always
-    be blank. Please note that in order to return the pid of of a network process running on the system, this script
-    must be ran as root.
+    Function to return a list of udp connection utilizing ipv6. Please note
+    that UDP is stateless, so state will always be blank. Please note that in
+    order to return the pid of of a network process running on the system, this
+    script must be ran as root.
     '''
 
-    udpcontent =_udp6load()
+    udpcontent = _udp6load()
     udpresult = []
     for line in udpcontent:
         line_array = _remove_empty(line.split(' '))
-        l_host,l_port = _convert_ipv6_port(line_array[1])
-        r_host,r_port = _convert_ipv6_port(line_array[2])
+        l_host, l_port = _convert_ipv6_port(line_array[1])
+        r_host, r_port = _convert_ipv6_port(line_array[2])
         udp_id = line_array[0]
-        udp_state ='Stateless' #UDP is stateless
+        udp_state = 'Stateless'  # UDP is stateless
         uid = pwd.getpwuid(int(line_array[7]))[0]
         inode = line_array[9]
         pid = _get_pid_of_inode(inode)
@@ -184,13 +210,16 @@ def netstat_udp6():
         except:
             exe = None
 
-        nline = [udp_id, uid, l_host+':'+l_port, r_host+':'+r_port, udp_state, pid, exe]
+        nline = [udp_id, uid, l_host+':'+l_port, r_host+':'+r_port, udp_state,
+                 pid, exe]
         udpresult.append(nline)
     return udpresult
 
+
 def packet_socket():
     '''
-    Function to return a list of pids and process names utilizing packet sockets.
+    Function to return a list of pids and process names utilizing packet
+    sockets.
     '''
 
     packetcontent = _packetload()
@@ -208,21 +237,23 @@ def packet_socket():
         packetresult.append(nline)
     return packetresult
 
+
 def _get_pid_of_inode(inode):
     '''
-    To retrieve the process pid, check every running process and look for one using
-    the given inode.
+    To retrieve the process pid, check every running process and look for one
+    using the given inode.
     '''
     for item in glob.glob('/proc/[0-9]*/fd/[0-9]*'):
         try:
-            if re.search(inode,os.readlink(item)):
+            if re.search(inode, os.readlink(item)):
                 return item.split('/')[2]
         except:
             pass
     return None
 
 if __name__ == '__main__':
-    print "\nLegend: Connection ID, UID, localhost:localport, remotehost:remoteport, state, pid, exe name"
+    print "\nLegend: Connection ID, UID, localhost:localport, remotehost:"\
+          "remoteport, state, pid, exe name"
     print "\nTCP (v4) Results:\n"
     for conn_tcp in netstat_tcp4():
         print conn_tcp


### PR DESCRIPTION
Original pep8 mishaps:

```
netstat.py:14:9: E126 continuation line over-indented for hanging indent
netstat.py:14:13: E231 missing whitespace after ':'
netstat.py:15:13: E231 missing whitespace after ':'
netstat.py:16:13: E231 missing whitespace after ':'
netstat.py:17:13: E231 missing whitespace after ':'
netstat.py:18:13: E231 missing whitespace after ':'
netstat.py:19:13: E231 missing whitespace after ':'
netstat.py:20:13: E231 missing whitespace after ':'
netstat.py:21:13: E231 missing whitespace after ':'
netstat.py:22:13: E231 missing whitespace after ':'
netstat.py:23:13: E231 missing whitespace after ':'
netstat.py:24:13: E231 missing whitespace after ':'
netstat.py:27:1: E302 expected 2 blank lines, found 1
netstat.py:29:24: E231 missing whitespace after ','
netstat.py:34:1: E302 expected 2 blank lines, found 1
netstat.py:36:24: E231 missing whitespace after ','
netstat.py:41:1: E302 expected 2 blank lines, found 1
netstat.py:43:24: E231 missing whitespace after ','
netstat.py:48:1: E302 expected 2 blank lines, found 1
netstat.py:50:24: E231 missing whitespace after ','
netstat.py:55:1: E302 expected 2 blank lines, found 1
netstat.py:56:80: E501 line too long (91 > 79 characters)
netstat.py:57:26: E231 missing whitespace after ','
netstat.py:62:1: E302 expected 2 blank lines, found 1
netstat.py:63:21: E231 missing whitespace after ','
netstat.py:65:1: E302 expected 2 blank lines, found 1
netstat.py:66:29: E231 missing whitespace after ','
netstat.py:66:48: E231 missing whitespace after ','
netstat.py:66:67: E231 missing whitespace after ','
netstat.py:66:80: E501 line too long (86 > 79 characters)
netstat.py:69:1: E302 expected 2 blank lines, found 1
netstat.py:70:5: E265 block comment should start with '# '
netstat.py:71:17: E231 missing whitespace after ','
netstat.py:71:24: E231 missing whitespace after ','
netstat.py:71:31: E231 missing whitespace after ','
netstat.py:71:38: E231 missing whitespace after ','
netstat.py:71:47: E231 missing whitespace after ','
netstat.py:71:56: E231 missing whitespace after ','
netstat.py:71:65: E231 missing whitespace after ','
netstat.py:71:73: E231 missing whitespace after ','
netstat.py:71:80: E501 line too long (145 > 79 characters)
netstat.py:71:82: E231 missing whitespace after ','
netstat.py:71:91: E231 missing whitespace after ','
netstat.py:71:100: E231 missing whitespace after ','
netstat.py:71:109: E231 missing whitespace after ','
netstat.py:71:118: E231 missing whitespace after ','
netstat.py:71:127: E231 missing whitespace after ','
netstat.py:71:136: E231 missing whitespace after ','
netstat.py:74:1: E302 expected 2 blank lines, found 1
netstat.py:75:37: E225 missing whitespace around operator
netstat.py:77:1: E302 expected 2 blank lines, found 1
netstat.py:78:9: E231 missing whitespace after ','
netstat.py:79:21: E231 missing whitespace after ','
netstat.py:81:1: E302 expected 2 blank lines, found 1
netstat.py:82:9: E231 missing whitespace after ','
netstat.py:83:22: E231 missing whitespace after ','
netstat.py:85:1: E302 expected 2 blank lines, found 1
netstat.py:88:80: E501 line too long (86 > 79 characters)
netstat.py:92:17: E225 missing whitespace around operator
netstat.py:95:80: E501 line too long (94 > 79 characters)
netstat.py:96:15: E231 missing whitespace after ','
netstat.py:96:58: E261 at least two spaces before inline comment
netstat.py:96:80: E501 line too long (107 > 79 characters)
netstat.py:97:15: E231 missing whitespace after ','
netstat.py:101:80: E501 line too long (92 > 79 characters)
netstat.py:103:80: E501 line too long (84 > 79 characters)
netstat.py:108:80: E501 line too long (84 > 79 characters)
netstat.py:112:1: E302 expected 2 blank lines, found 1
netstat.py:114:80: E501 line too long (119 > 79 characters)
netstat.py:121:15: E231 missing whitespace after ','
netstat.py:122:15: E231 missing whitespace after ','
netstat.py:125:47: E211 whitespace before '['
netstat.py:128:80: E501 line too long (84 > 79 characters)
netstat.py:133:80: E501 line too long (84 > 79 characters)
netstat.py:137:1: E302 expected 2 blank lines, found 1
netstat.py:139:80: E501 line too long (116 > 79 characters)
netstat.py:140:80: E501 line too long (114 > 79 characters)
netstat.py:144:17: E225 missing whitespace around operator
netstat.py:148:15: E231 missing whitespace after ','
netstat.py:149:15: E231 missing whitespace after ','
netstat.py:151:20: E225 missing whitespace around operator
netstat.py:151:31: E261 at least two spaces before inline comment
netstat.py:151:32: E262 inline comment should start with '# '
netstat.py:160:80: E501 line too long (88 > 79 characters)
netstat.py:164:1: E302 expected 2 blank lines, found 1
netstat.py:166:80: E501 line too long (119 > 79 characters)
netstat.py:167:80: E501 line too long (116 > 79 characters)
netstat.py:171:17: E225 missing whitespace around operator
netstat.py:175:15: E231 missing whitespace after ','
netstat.py:176:15: E231 missing whitespace after ','
netstat.py:178:20: E225 missing whitespace around operator
netstat.py:178:31: E261 at least two spaces before inline comment
netstat.py:178:32: E262 inline comment should start with '# '
netstat.py:187:80: E501 line too long (88 > 79 characters)
netstat.py:191:1: E302 expected 2 blank lines, found 1
netstat.py:193:80: E501 line too long (81 > 79 characters)
netstat.py:211:1: E302 expected 2 blank lines, found 1
netstat.py:213:80: E501 line too long (83 > 79 characters)
netstat.py:218:31: E231 missing whitespace after ','
netstat.py:225:80: E501 line too long (106 > 79 characters)
```

After cleaning up code:

```
netstat.py:112:80: E501 line too long (91 > 79 characters)
netstat.py:113:80: E501 line too long (109 > 79 characters)
```

Which are two lines with comments, it seemed ridiculous to change those lines though.

I audited these using Flake8
